### PR TITLE
Default package crash fix and same directory tree for annotations

### DIFF
--- a/plugin/src/org/jetbrains/kannotator/plugin/actions/AnnotateJarAction.kt
+++ b/plugin/src/org/jetbrains/kannotator/plugin/actions/AnnotateJarAction.kt
@@ -24,6 +24,7 @@ public class AnnotateJarAction: AnAction() {
                     outputPath = dlg.getConfiguredOutputPath(),
                     libJarFiles = dlg.getCheckedLibToJarFiles().map { it.key to it.value.map { file -> VfsUtilCore.virtualToIoFile(file) }.toSet() }.toMap(),
                     addAnnotationsRoots = dlg.shouldAddAnnotationsRoots(),
+                    useOneCommonTree = dlg.useOneCommonTree(),
                     removeOtherRoots = dlg.shouldRemoveAllOtherRoots()
             )
 

--- a/plugin/src/org/jetbrains/kannotator/plugin/actions/dialog/InferAnnotationDialog.form
+++ b/plugin/src/org/jetbrains/kannotator/plugin/actions/dialog/InferAnnotationDialog.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.jetbrains.kannotator.plugin.actions.dialog.InferAnnotationDialog">
-  <grid id="27dc6" binding="contentPanel" layout-manager="GridLayoutManager" row-count="9" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="contentPanel" layout-manager="GridLayoutManager" row-count="10" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -10,7 +10,7 @@
     <children>
       <component id="817a" class="javax.swing.JCheckBox" binding="nullabilityCheckBox" default-binding="true">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <selected value="true"/>
@@ -19,7 +19,7 @@
       </component>
       <component id="bb1ce" class="javax.swing.JCheckBox" binding="kotlinSignaturesCheckBox" default-binding="true">
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <enabled value="false"/>
@@ -28,7 +28,7 @@
       </component>
       <component id="19b21" class="javax.swing.JLabel" binding="outputDirectoryLabel">
         <constraints>
-          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
             <preferred-size width="90" height="14"/>
           </grid>
         </constraints>
@@ -36,15 +36,9 @@
           <text value="Output &amp;directory:"/>
         </properties>
       </component>
-      <component id="95a5f" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="outputDirectory">
-        <constraints>
-          <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties/>
-      </component>
       <component id="99744" class="com.intellij.ui.TitledSeparator">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Annotation types"/>
@@ -52,7 +46,7 @@
       </component>
       <component id="94906" class="com.intellij.ui.TitledSeparator">
         <constraints>
-          <grid row="5" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Output"/>
@@ -60,7 +54,7 @@
       </component>
       <component id="7cd1c" class="javax.swing.JLabel" binding="jarsTreeLabel">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Select &amp;jar files to be annotated: "/>
@@ -68,7 +62,7 @@
       </component>
       <scrollpane id="711c2" class="com.intellij.ui.components.JBScrollPane" binding="jarsTreeScrollPane">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="3" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -76,7 +70,7 @@
       </scrollpane>
       <component id="3e425" class="javax.swing.JCheckBox" binding="addLibrariesRootAutomaticallyCheckbox">
         <constraints>
-          <grid row="7" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="8" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <selected value="true"/>
@@ -85,11 +79,26 @@
       </component>
       <component id="d1e90" class="javax.swing.JCheckBox" binding="removeAllOtherAnnotationsRootsCheckbox">
         <constraints>
-          <grid row="8" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="9" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Remove &amp;all other annotations roots"/>
         </properties>
+      </component>
+      <component id="9aaf9" class="javax.swing.JCheckBox" binding="useCommonTreeCheckBox">
+        <constraints>
+          <grid row="6" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Use common directory tree"/>
+          <toolTipText value="Output all annotations to the same directory tree, instead of separate ones for each library. Be aware of possible name conflicts!"/>
+        </properties>
+      </component>
+      <component id="95a5f" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="outputDirectory">
+        <constraints>
+          <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
       </component>
     </children>
   </grid>

--- a/plugin/src/org/jetbrains/kannotator/plugin/actions/dialog/InferAnnotationDialog.java
+++ b/plugin/src/org/jetbrains/kannotator/plugin/actions/dialog/InferAnnotationDialog.java
@@ -36,6 +36,7 @@ public class InferAnnotationDialog extends DialogWrapper {
     JLabel jarsTreeLabel;
     JCheckBox addLibrariesRootAutomaticallyCheckbox;
     JCheckBox removeAllOtherAnnotationsRootsCheckbox;
+    JCheckBox useCommonTreeCheckBox;
 
     // Not from gui designer
     LibraryCheckboxTree libraryTree;
@@ -119,6 +120,17 @@ public class InferAnnotationDialog extends DialogWrapper {
         }
 
         return configuredOutputPath;
+    }
+
+    /**
+     * Check whether we should create a separate directory for each annotated library or
+     * output annotations to the same directory tree.
+     * @return false if each library has its own branch, true otherwise
+     */
+    @NotNull
+    public boolean useOneCommonTree()
+    {
+        return useCommonTreeCheckBox.isSelected();
     }
 
     @Override


### PR DESCRIPTION
- fixed a crash on encountering default package
- new test jar file with an empty class stub located in default package.
- implemented an option to output all annotation results to the same directory tree (instead of creating a separate subtree for each library in the output directory).

Now when picking a library with the following symbols in its name (defined in project properties):
  \/:*?\"<>|
  AND putting every library's annotation into separate directory subtrees, we will replace these symbols for underscores in names of directories, containing subtrees.
  The reason is that these characters are not allowed as parts of filenames (i.e. in Windows).
