### PR TITLE
Fixing missing dependencies of IDEA plugin (from scene lib and plume lib...

### DIFF
--- a/.idea/artifacts/KAnnotatorPlugin.xml
+++ b/.idea/artifacts/KAnnotatorPlugin.xml
@@ -9,6 +9,7 @@
             <element id="dir-copy" path="$PROJECT_DIR$/plugin/META-INF" />
           </element>
           <element id="module-output" name="kannotator" />
+          <element id="module-output" name="scene-lib" />
         </element>
         <element id="library" level="project" name="asm-debug-all-4.0" />
         <element id="library" level="project" name="gs-collections-2.0" />
@@ -16,6 +17,7 @@
           <element id="dir-copy" path="$PROJECT_DIR$/license" />
         </element>
         <element id="file-copy" path="$PROJECT_DIR$/lib/kotlin-runtime.jar" />
+        <element id="library" level="project" name="plume" />
       </element>
     </root>
   </artifact>


### PR DESCRIPTION
...). It was not a bug, that affects functionality (the corresponding calls are never executed in plugin), but made 'Publish Plugin' fail on TeamCity because of missing dependencies.
