### PR TITLE
fixing android annotations

### DIFF
--- a/android-custom/README.md
+++ b/android-custom/README.md
@@ -1,0 +1,8 @@
+# Android SDK annotations
+
+Android SDK annotations are inferred in the same way as JDK annotations with minor subtle difference.
+
+We would like to have as few conflicts with annotations supplied with Android Studio as possible.
+For this reason, we remove annotations that conflict with Studio annotations (see `androidCombine.kt`).
+Unfortunately, after this removal hierarchy is broken. Fortunately, a number of such broken annotations is
+small, so it is possible to fix it via manual removal of such broken annotations. This is what file `exclude.xml` for.

--- a/android-custom/exclude.xml
+++ b/android-custom/exclude.xml
@@ -1,0 +1,59 @@
+<root>
+    <item name='android.widget.AbsListView void onRestoreInstanceState(android.os.Parcelable) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='android.widget.AbsSpinner void onRestoreInstanceState(android.os.Parcelable) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='android.widget.AdapterViewAnimator void onRestoreInstanceState(android.os.Parcelable) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='android.widget.CompoundButton void onRestoreInstanceState(android.os.Parcelable) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='android.widget.DatePicker void onRestoreInstanceState(android.os.Parcelable) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='android.widget.ExpandableListView void onRestoreInstanceState(android.os.Parcelable) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='android.widget.HorizontalScrollView void onRestoreInstanceState(android.os.Parcelable) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='android.widget.ProgressBar void onRestoreInstanceState(android.os.Parcelable) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='android.widget.ScrollView void onRestoreInstanceState(android.os.Parcelable) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='android.widget.Spinner void onRestoreInstanceState(android.os.Parcelable) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='android.widget.TextView void onRestoreInstanceState(android.os.Parcelable) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='android.widget.TimePicker void onRestoreInstanceState(android.os.Parcelable) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='android.widget.SimpleCursorAdapter java.lang.CharSequence convertToString(android.database.Cursor) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='android.widget.TextView void findViewsWithText(java.util.ArrayList&lt;android.view.View&gt;, java.lang.CharSequence, int) 1'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='android.view.ViewGroup void findViewsWithText(java.util.ArrayList&lt;android.view.View&gt;, java.lang.CharSequence, int) 1'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='android.view.ViewGroup void addFocusables(java.util.ArrayList&lt;android.view.View&gt;, int, int) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='android.webkit.WebView void setLayoutParams(android.view.ViewGroup.LayoutParams) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='android.database.ContentObservable void registerObserver(android.database.ContentObserver) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='android.test.mock.MockResources int getIdentifier(java.lang.String, java.lang.String, java.lang.String) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+</root>

--- a/android-sdk-annotations-kotlin-plugin/java/util/annotations.xml
+++ b/android-sdk-annotations-kotlin-plugin/java/util/annotations.xml
@@ -2350,7 +2350,8 @@
     </item>
     <item name='java.util.Collections T max(java.util.Collection&lt;? extends T&gt;)'>
         <annotation name='jet.runtime.typeinfo.KotlinSignature'>
-            <val name="value" val="&quot;fun &lt;T: Comparable&lt;T&gt;&gt; max(coll : Collection&lt;T&gt;) : T&quot;"/>
+            <val name="value"
+                 val="&quot;fun &lt;T: Any&gt; max(coll : Collection&lt;T&gt;) : T where T: Comparable&lt;T&gt;&quot;"/>
         </annotation>
     </item>
     <item name='java.util.ServiceLoader java.util.ServiceLoader&lt;S&gt; load(java.lang.Class&lt;S&gt;, java.lang.ClassLoader) 0'>
@@ -3123,7 +3124,8 @@
     </item>
     <item name='java.util.Collections T min(java.util.Collection&lt;? extends T&gt;)'>
         <annotation name='jet.runtime.typeinfo.KotlinSignature'>
-            <val name="value" val="&quot;fun &lt;T: Comparable&lt;T&gt;&gt; min(coll : Collection&lt;T&gt;) : T&quot;"/>
+            <val name="value"
+                 val="&quot;fun &lt;T: Any&gt; min(coll : Collection&lt;T&gt;) : T where T: Comparable&lt;T&gt;&quot;"/>
         </annotation>
     </item>
     <item name='java.util.Arrays void fill(float[], int, int, float)'>


### PR DESCRIPTION
Fixes `AndroidSdkAnnotationsValidityTest` from jetbrains/kotlin@748a0f87200eb4ca9b9f6821be1ed0a749dd3e81 
- port of kotlin annotations
- including java.lang.AbstractStringBuilder during combine phase
- extra pass of removing broken annotations
